### PR TITLE
feat: align with upstream, fork name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "Test"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - "main"
 
 # Only allow one workflow run at a time per PR
 concurrency:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm cit
+      - run: npm cit --quiet
         timeout-minutes: 5
 
   publish-npm:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,7 +8,8 @@ on:
     types: ["created"]
 
 jobs:
-  build:
+  test:
+    name: "Test"
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +20,8 @@ jobs:
         timeout-minutes: 5
 
   publish-npm:
-    needs: build
+    name: "Publish to npm"
+    needs: ["test"]
     permissions:
       contents: read
       id-token: write
@@ -30,7 +32,6 @@ jobs:
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_PUBLISH_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-index.cjs

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 
 .prettierrc.json
 .prettierignore
+*.spec.*

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 .prettierrc.json
+.github

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
-.prettierrc.json
 .github
+
+.prettierrc.json
+.prettierignore

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# post-task
+# @dagher/post-task
 
 A pre-configured progressively-enhancement utility function based on the
 [Scheduler API](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
@@ -38,15 +38,10 @@ web vital and of course the smooth interaction which it tries to measure.
 ## Use
 
 ```js
-import postTask from "post-task";
+import postTask from "@dagher/post-task";
 
 // ...
 postTask(() => {
   trackEvent("something-happened");
 }, "background");
 ```
-
-## Formats
-
-This package is equally available as ESM and CJS and has a single, default
-export.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright © 2024 Adevinta
+// Copyright © 2025 Daniel Arthur Gallagher
 
-declare module "post-task" {
+declare module "@dagher/post-task" {
 	/**
 	 * Queues an arbitrary task to be scheduled for execution with the given
 	 * priority.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,8 +3,17 @@
 
 declare module "post-task" {
 	/**
-	 * Queues an arbitrary task to be executed in the browser, with the given priority.
-	 * Allows breaking up the work of potentially long-running tasks to avoid blocking the main thread.
+	 * Queues an arbitrary task to be scheduled for execution with the given
+	 * priority.
+	 *
+	 * Allows the discrete and prioritised queuing of tasks which if run serially
+	 * would block the main thread, but which do not have to be run immediately.
+	 *
+	 * @param task The callback to be executed.
+	 * @param priority The priority of the task, following the
+	 * Scheduler API.
+	 * @returns A promise that resolves when the task is executed,
+	 * in case it needs to be tracked.
 	 */
 	export default function postTask(
 		task: () => void,

--- a/index.mjs
+++ b/index.mjs
@@ -4,74 +4,76 @@
 /**
  * The priority of the task: these are the priorities of the Scheduler API.
  * @typedef {('background' | 'user-visible' | 'user-blocking')} SchedulerPriority
- */
-
-/** @typedef {Record<SchedulerPriority, number>} PriorityConfigurationFallback */
-
-/**
- * The timeouts used for requestIdleCallback, which define the maximum time the task can be delayed.
- * The task will be executed as soon as possible, in idle time, but guaranteed within the timeout.
- * @type {PriorityConfigurationFallback}
- */
-const priorityIdleTimeouts = Object.create(null, {
-	background: { value: 1000, enumerable: true },
-	"user-visible": { value: 100, enumerable: true },
-	"user-blocking": { value: 50, enumerable: true },
-});
-
-/**
- * The timeouts used for setTimeout, which define the delay before the task is executed.
- * @type {PriorityConfigurationFallback}
+ *
+ * The timeouts used for `setTimeout`, which define the minimum delay in
+ * milliseconds before the callback will be executed.
+ * @type {Record<SchedulerPriority, number>}
  */
 const priorityCallbackDelays = Object.create(null, {
-	background: { value: 150, enumerable: true },
-	"user-visible": { value: 0, enumerable: true },
-	"user-blocking": { value: 0, enumerable: true },
+	/**
+	 * A 150ms duration defines a "long task" for the Web Vitals.
+	 * Waiting at least that long will give a better chance for long queues of
+	 * work to be broken up.
+	 *
+	 * The task will then be scheduled as part of the next event loop, but
+	 * ideally without directly adding to congestion if the CPU is busy.
+	 */
+	background: { value: 150 },
+	/**
+	 * User-visible tasks are scheduled immediately, and although this is the
+	 * same timeout as for `"user-blocking"`, the fallback for that case will
+	 * almost always schedule a microtask with the `queueMicrotask` function;
+	 * while the 0ms timeout here will schedule a **macro**task which will run
+	 * with a lower priority in the event loop.
+	 */
+	"user-visible": { value: 0 },
+	/**
+	 * User-blocking callbacks are scheduled immediately, mirroring the
+	 * user-visible case as a fallback for the unlikely case that
+	 * `queueMicrotask` is not available.
+	 */
+	"user-blocking": { value: 0 },
 });
 
-/** @typedef {() => void} Task */
-
 /**
- * Queues an arbitrary task to be executed in the browser, with the given priority.
- * Allows breaking up the work of potentially long-running tasks to avoid blocking the main thread.
- * @param {Task} task The callback to be executed.
- * @param {SchedulerPriority} priority The priority of the task, following the Scheduler API.
- * @returns {Promise<void>} A promise that resolves when the task is executed, in case it needs to be tracked.
+ * Queues an arbitrary task to be scheduled for execution with the given
+ * priority.
+ *
+ * Allows the discrete and prioritised queuing of tasks which if run serially
+ * would block the main thread, but which do not have to be run immediately.
+ *
+ * @param {() => void} task The callback to be executed.
+ * @param {SchedulerPriority} priority The priority of the task, following the
+ * Scheduler API.
+ * @returns {Promise<void>} A promise that resolves when the task is executed,
+ * in case it needs to be tracked.
  */
 const postTask = (task, priority) => {
-	if (typeof window !== "undefined") {
-		// Prefer to use the Scheduler API, if available.
-		if ("scheduler" in window) {
-			return scheduler.postTask(task, {
-				priority,
+	// Prefer to use the Scheduler API, if available.
+	if ("scheduler" in globalThis) {
+		return globalThis.scheduler.postTask(task, {
+			priority,
+		});
+	}
+	// Otherwise, if available and for user-blocking tasks,
+	// use the native `queueMicrotask`.
+	else if (priority === "user-blocking" && "queueMicrotask" in globalThis) {
+		return new Promise((resolve) => {
+			globalThis.queueMicrotask(() => {
+				task();
+				resolve();
 			});
-		}
-		// Otherwise, if possible, queue the tracking in browser idle time.
-		else if ("requestIdleCallback" in window) {
-			return new Promise((resolve) => {
-				requestIdleCallback(
-					() => {
-						task();
-						resolve();
-					},
-					{ timeout: priorityIdleTimeouts[priority] },
-				);
-			});
-		}
-		// Otherwise set a timeout with the appropriate delay
-		else {
-			return new Promise((resolve) => {
-				setTimeout(() => {
-					task();
-					resolve();
-				}, priorityCallbackDelays[priority]);
-			});
-		}
-	} else {
-		// On Node.js, just run the task immediately.
-		// This should be an edge case, but we will not suppress tasks.
-		task();
-		return Promise.resolve();
+		});
+	}
+	// Otherwise, and always for the lower priorities on Node.js where the
+	// Scheduler API is not available, set a timeout with the appropriate delay.
+	else {
+		return new Promise((resolve) => {
+			globalThis.setTimeout(() => {
+				task();
+				resolve();
+			}, priorityCallbackDelays[priority]);
+		});
 	}
 };
 

--- a/index.spec.mjs
+++ b/index.spec.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { test, suite, before, after } from "node:test";
+import postTask from "./index.mjs";
+
+suite("postTask", () => {
+	const {
+		queueMicrotask: queueMicrotaskOriginal,
+		scheduler: schedulerOriginal,
+	} = globalThis;
+
+	suite("when neither the scheduler nor queueMicrotask are available", () => {
+		before(() => {
+			delete globalThis.queueMicrotask;
+			delete globalThis.scheduler;
+		});
+
+		after(() => {
+			globalThis.queueMicrotask = queueMicrotaskOriginal;
+			globalThis.scheduler = schedulerOriginal;
+		});
+
+		test("all priorities should call back", (context) => {
+			context.mock.timers.enable(["setTimeout"]);
+
+			const callback = context.mock.fn();
+
+			// Schedule all tasks synchronously: the loops will queue all three
+			// tasks because there is no `await`.
+			postTask(callback, "user-blocking");
+			postTask(callback, "user-visible");
+			postTask(callback, "background");
+
+			assert.equal(callback.mock.calls.length, 0);
+
+			// Allow the minimal tick to pass, which will enable both timeouts
+			// with a 0ms delay to run, and not the third which has a minimum
+			context.mock.timers.tick(0);
+			assert.equal(callback.mock.calls.length, 2);
+
+			// Allow the 150ms delay for the background task to pass.
+			context.mock.timers.tick(150);
+			assert.equal(callback.mock.calls.length, 3);
+		});
+	});
+
+	suite("when `queueMicrotask` is available", () => {
+		before(() => {
+			delete globalThis.scheduler;
+		});
+
+		after(() => {
+			globalThis.queueMicrotask = queueMicrotaskOriginal;
+			globalThis.scheduler = schedulerOriginal;
+		});
+
+		test("all priorities should call back", async (context) => {
+			context.mock.timers.enable(["setTimeout"]);
+
+			const callback = context.mock.fn();
+
+			// Schedule all tasks synchronously: the loops will queue all three
+			// tasks because there is no `await`.
+			postTask(callback, "user-blocking");
+			postTask(callback, "user-visible");
+			postTask(callback, "background");
+
+			assert.equal(callback.mock.calls.length, 0);
+
+			// Await for the resolution of a microtask: giving that control back to
+			// the event loop results in it running _all_ microtasks, including the
+			// queued one for the `"user-blocking"` task.
+			await Promise.resolve();
+			assert.equal(callback.mock.calls.length, 1);
+
+			// Allow the minimal tick to pass, which will enable both timeouts
+			// with a 0ms delay to run, and not the third which has a minimum
+			context.mock.timers.tick(0);
+			assert.equal(callback.mock.calls.length, 2);
+
+			// Allow the 150ms delay for the background task to pass.
+			context.mock.timers.tick(150);
+			assert.equal(callback.mock.calls.length, 3);
+		});
+	});
+
+	suite("when `scheduler` is available", async () => {
+		after(() => {
+			globalThis.scheduler = schedulerOriginal;
+		});
+
+		test("all priorities should be scheduled", async (context) => {
+			// Mock the function which is to be called
+			const mockSchedulerPostTask = context.mock.fn();
+			globalThis.scheduler = { postTask: mockSchedulerPostTask };
+
+			const noop = () => undefined;
+
+			// Schedule all tasks synchronously
+			postTask(noop, "user-blocking");
+			postTask(noop, "user-visible");
+			postTask(noop, "background");
+
+			// Assert that the control flow correctly forwards the tasks:
+			// the callback is handled by the scheduler, so asserting on the callback
+			// would be testing the mock, and not useful.
+			assert.equal(mockSchedulerPostTask.mock.calls.length, 3);
+			assert.deepEqual(mockSchedulerPostTask.mock.calls[0].arguments, [
+				noop,
+				{
+					priority: "user-blocking",
+				},
+			]);
+			assert.deepEqual(mockSchedulerPostTask.mock.calls[1].arguments, [
+				noop,
+				{
+					priority: "user-visible",
+				},
+			]);
+			assert.deepEqual(mockSchedulerPostTask.mock.calls[2].arguments, [
+				noop,
+				{
+					priority: "background",
+				},
+			]);
+		});
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@dagher/post-task",
-	"version": "1.0.0",
+	"version": "1.0.0-dev.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dagher/post-task",
-			"version": "1.0.0",
+			"version": "1.0.0-dev.1",
 			"license": "MIT",
 			"devDependencies": {
 				"prettier": "3.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@danieleloscozzese/post-task",
+	"name": "@dagher/post-task",
 	"version": "1.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@danieleloscozzese/post-task",
+			"name": "@dagher/post-task",
 			"version": "1.0.0",
 			"license": "MIT",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 	},
 	"version": "1.0.0",
 	"scripts": {
-		"test": "echo 'no tests yet'; exit 0;",
+		"pretest": "node --check index.mjs",
+		"test": "node --disable-warning=ExperimentalWarning ./index.spec.mjs",
 		"prepublishOnly": "sed 's/export default/module.exports =/g' ./index.mjs > index.cjs"
 	},
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,22 +1,30 @@
 {
-	"name": "@danieleloscozzese/post-task",
+	"name": "@dagher/post-task",
 	"license": "MIT",
-	"description": "A polyfill for the Scheduler API with a pre-configured progressively-enhanced function helps to split long-running tasks into chunks.",
 	"type": "module",
+	"description": "A polyfill for the Scheduler API with a pre-configured progressively-enhanced function helps to split long-running tasks into chunks.",
+	"version": "1.0.0",
 	"exports": {
 		"types": "./index.d.ts",
 		"import": "./index.mjs",
 		"require": "./index.cjs"
 	},
-	"version": "1.0.0",
 	"scripts": {
 		"pretest": "node --check index.mjs",
 		"test": "node --disable-warning=ExperimentalWarning ./index.spec.mjs",
 		"prepublishOnly": "sed 's/export default/module.exports =/g' ./index.mjs > index.cjs"
 	},
+	"devDependencies": {
+		"prettier": "3.4.2"
+	},
+	"packageManager": "npm@11.0.0+sha512.11dff29565d2297c74e7c594a9762581bde969f0aa5cbe6f5b3644bf008a16c065ece61094d9ffbb81125be38df8e1ba43eb8244b3d30c61eb797e9a2440e3ec",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/danieleloscozzese/post-task.git"
+	},
+	"homepage": "https://github.com/danieleloscozzese/post-task#readme",
+	"bugs": {
+		"url": "https://github.com/danieleloscozzese/post-task/issues"
 	},
 	"keywords": [
 		"scheduler",
@@ -28,13 +36,5 @@
 		"name": "Daniel Arthur Gallagher",
 		"email": "npm@danielarthurgallagher.dev",
 		"url": "https://danielarthurgallagher.dev"
-	},
-	"homepage": "https://github.com/danieleloscozzese/post-task#readme",
-	"bugs": {
-		"url": "https://github.com/danieleloscozzese/post-task/issues"
-	},
-	"devDependencies": {
-		"prettier": "3.4.2"
-	},
-	"packageManager": "npm@11.0.0+sha512.11dff29565d2297c74e7c594a9762581bde969f0aa5cbe6f5b3644bf008a16c065ece61094d9ffbb81125be38df8e1ba43eb8244b3d30c61eb797e9a2440e3ec"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"license": "MIT",
 	"type": "module",
 	"description": "A polyfill for the Scheduler API with a pre-configured progressively-enhanced function helps to split long-running tasks into chunks.",
-	"version": "1.0.0",
+	"version": "1.0.0-dev.1",
 	"exports": {
 		"types": "./index.d.ts",
 		"import": "./index.mjs"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,11 @@
 	"version": "1.0.0",
 	"exports": {
 		"types": "./index.d.ts",
-		"import": "./index.mjs",
-		"require": "./index.cjs"
+		"import": "./index.mjs"
 	},
 	"scripts": {
 		"pretest": "node --check index.mjs",
-		"test": "node --disable-warning=ExperimentalWarning ./index.spec.mjs",
-		"prepublishOnly": "sed 's/export default/module.exports =/g' ./index.mjs > index.cjs"
+		"test": "node --disable-warning=ExperimentalWarning ./index.spec.mjs"
 	},
 	"devDependencies": {
 		"prettier": "3.4.2"


### PR DESCRIPTION
Correctly point to the fork this time, not repeating the mistake of adevinta/post-task#4 (now reverted).
Integrates all the upstream changes, and forks the package with a new name and a dev version: notably drops the CJS version.